### PR TITLE
- force latest xpc-connection and bluetooth-hci-socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "debug": "^2.2.0"
   },
   "optionalDependencies": {
-    "bluetooth-hci-socket": "~0.3.1",
+    "bluetooth-hci-socket": "~0.3.3",
     "bplist-parser": "0.0.6",
-    "xpc-connection": "~0.1.3"
+    "xpc-connection": "~0.1.4"
   }
 }


### PR DESCRIPTION
(mostly for Node.js 4.0)